### PR TITLE
Add extra error classes to handle server errors.

### DIFF
--- a/lib/json_api_client/errors.rb
+++ b/lib/json_api_client/errors.rb
@@ -44,6 +44,25 @@ module JsonApiClient
     class NotAuthorized < ClientError
     end
 
+    class NotFound < ClientError
+      attr_reader :uri
+      def initialize(uri)
+        @uri = uri
+
+        msg = "Couldn't find resource at: #{uri.to_s}"
+        super nil, msg
+      end
+    end
+
+    class Conflict < ClientError
+      def initialize(env, msg = 'Resource already exists')
+        super env, msg
+      end
+    end
+
+    class TooManyRequests < ClientError
+    end
+
     class ConnectionError < ApiError
     end
 
@@ -59,23 +78,16 @@ module JsonApiClient
       end
     end
 
-    class Conflict < ServerError
-      def initialize(env, msg = 'Resource already exists')
-        super env, msg
-      end
-    end
-
-    class NotFound < ServerError
-      attr_reader :uri
-      def initialize(uri)
-        @uri = uri
-
-        msg = "Couldn't find resource at: #{uri.to_s}"
-        super nil, msg
-      end
-    end
-
     class InternalServerError < ServerError
+    end
+
+    class BadGateway < ServerError
+    end
+
+    class ServiceUnavailable < ServerError
+    end
+
+    class GatewayTimeout < ServerError
     end
 
     class UnexpectedStatus < ServerError

--- a/lib/json_api_client/errors.rb
+++ b/lib/json_api_client/errors.rb
@@ -54,6 +54,9 @@ module JsonApiClient
       end
     end
 
+    class RequestTimeout < ClientError
+    end
+
     class Conflict < ClientError
       def initialize(env, msg = 'Resource already exists')
         super env, msg

--- a/lib/json_api_client/middleware/status.rb
+++ b/lib/json_api_client/middleware/status.rb
@@ -38,6 +38,8 @@ module JsonApiClient
           raise Errors::AccessDenied, env
         when 404
           raise Errors::NotFound, env[:url]
+        when 408
+          raise Errors::RequestTimeout, env
         when 409
           raise Errors::Conflict, env
         when 422

--- a/lib/json_api_client/middleware/status.rb
+++ b/lib/json_api_client/middleware/status.rb
@@ -42,10 +42,18 @@ module JsonApiClient
           raise Errors::Conflict, env
         when 422
           # Allow to proceed as resource errors will be populated
+        when 429
+          raise Errors::TooManyRequests, env
         when 400..499
           raise Errors::ClientError, env
         when 500
           raise Errors::InternalServerError, env
+        when 502
+          raise Errors::BadGateway, env
+        when 503
+          raise Errors::ServiceUnavailable, env
+        when 504
+          raise Errors::GatewayTimeout, env
         when 501..599
           raise Errors::ServerError, env
         else

--- a/test/unit/errors_test.rb
+++ b/test/unit/errors_test.rb
@@ -96,6 +96,42 @@ class ErrorsTest < MiniTest::Test
     end
   end
 
+  def test_too_many_requests
+    stub_request(:get, "http://example.com/users")
+      .to_return(headers: {content_type: "text/plain"}, status: 429, body: "too many requests")
+
+    assert_raises JsonApiClient::Errors::TooManyRequests do
+      User.all
+    end
+  end
+
+  def test_bad_gateway
+    stub_request(:get, "http://example.com/users")
+      .to_return(headers: {content_type: "text/plain"}, status: 502, body: "bad gateway")
+
+    assert_raises JsonApiClient::Errors::BadGateway do
+      User.all
+    end
+  end
+
+  def test_service_unavailable
+    stub_request(:get, "http://example.com/users")
+      .to_return(headers: {content_type: "text/plain"}, status: 503, body: "service unavailable")
+
+    assert_raises JsonApiClient::Errors::ServiceUnavailable do
+      User.all
+    end
+  end
+
+  def test_gateway_timeout
+    stub_request(:get, "http://example.com/users")
+      .to_return(headers: {content_type: "text/plain"}, status: 504, body: "gateway timeout")
+
+    assert_raises JsonApiClient::Errors::GatewayTimeout do
+      User.all
+    end
+  end
+
   def test_errors_are_rescuable_by_default_rescue
     begin
       raise JsonApiClient::Errors::ApiError, "Something bad happened"

--- a/test/unit/errors_test.rb
+++ b/test/unit/errors_test.rb
@@ -96,6 +96,15 @@ class ErrorsTest < MiniTest::Test
     end
   end
 
+  def test_request_timeout
+    stub_request(:get, "http://example.com/users")
+      .to_return(headers: {content_type: "text/plain"}, status: 408, body: "request timeout")
+
+    assert_raises JsonApiClient::Errors::RequestTimeout do
+      User.all
+    end
+  end
+
   def test_too_many_requests
     stub_request(:get, "http://example.com/users")
       .to_return(headers: {content_type: "text/plain"}, status: 429, body: "too many requests")


### PR DESCRIPTION
In order to provide more granularity on the exceptions, we are adding some additional error classes for the common Server errors.

### Motivation

`json_api_client` doesn't give us enough granularity on the exceptions. Adding some additional clauses for the common ones like 502, 503, 504, 429 in here (e.g. JsonApiClient::GatewayTimeoutError) and then adding them into CarwowCore::Retryable in here to retry on before we start raising to bugsnag/counting as failures on HC would be good way to reduce the noise on both platform.

e.g. https://app.bugsnag.com/carwow/dealers-site/errors/6065a65c547bc400077c0f54?event_id=606c65b000773cede9540000&i=pd&m=eu

and 

https://app.bugsnag.com/carwow/dealers-site/errors/6065a65c547bc400077c0f54?event_id=606f05a1007737366dfe0000&i=pd&m=eu

 

See the whole conversation: https://carwow.slack.com/archives/C011H6KGV8S/p1617892756054600



https://carwow.kanbanize.com/ctrl_board/36/cards/32474/